### PR TITLE
Added examples of Zig and C

### DIFF
--- a/spin.toml
+++ b/spin.toml
@@ -104,3 +104,10 @@ files = [ { source = "fsharp-static-assets/assets", destination = "/" } ]
 [component.trigger]
 route = "/fsharp-static/..."
 executor = { type = "wagi" }
+
+[[component]]
+source = "zig-hello/main.wasm"
+id = "zig-hello"
+[component.trigger]
+route = "/zig-hello"
+executor = { type = "wagi" }

--- a/zig-hello/.gitignore
+++ b/zig-hello/.gitignore
@@ -1,0 +1,2 @@
+zig-cache/
+zig-out/

--- a/zig-hello/Makefile
+++ b/zig-hello/Makefile
@@ -1,0 +1,4 @@
+.PHONY: build
+build:
+	zig build-exe -O ReleaseSmall -target wasm32-wasi src/main.zig
+	zig build-exe -O ReleaseSmall -target wasm32-wasi hello.c -lc

--- a/zig-hello/README.md
+++ b/zig-hello/README.md
@@ -1,0 +1,3 @@
+# Zig Toolchain for Zig and C
+
+This example shows using the Zig toolchain to compile Zig and to compile C.

--- a/zig-hello/build.zig
+++ b/zig-hello/build.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
+
+    // Standard release options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
+    const mode = b.standardReleaseOptions();
+
+    const exe = b.addExecutable("zig-hello", "src/main.zig");
+    exe.setTarget(target);
+    exe.setBuildMode(mode);
+    exe.install();
+
+    const run_cmd = exe.run();
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+
+    const exe_tests = b.addTest("src/main.zig");
+    exe_tests.setTarget(target);
+    exe_tests.setBuildMode(mode);
+
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&exe_tests.step);
+}

--- a/zig-hello/hello.c
+++ b/zig-hello/hello.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+    printf("Content-Type: text/plain\n\n");
+    printf("Hello, World\n");
+}

--- a/zig-hello/spin.toml
+++ b/zig-hello/spin.toml
@@ -1,0 +1,20 @@
+spin_version = "1"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = "A Spin example HTTP application for Zig."
+name = "spin-kitchensink-zig"
+trigger = { type = "http", base = "/" }
+version = "1.0.0"
+
+[[component]]
+source = "main.wasm"
+id = "zig-hello"
+[component.trigger]
+route = "/zig-hello"
+executor = { type = "wagi" }
+
+[[component]]
+source = "hello.wasm"
+id = "c-hello"
+[component.trigger]
+route = "/c-hello"
+executor = { type = "wagi" }

--- a/zig-hello/src/main.zig
+++ b/zig-hello/src/main.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+pub fn main() !void {
+    const stdout = std.io.getStdOut().writer();
+    try stdout.print("content-type: text/plain\n\n", .{});
+    try stdout.print("Hello, {s}!\n", .{"world"});
+}


### PR DESCRIPTION
This uses the Zig toolchain to build both C and Zig Wasm binaries.

See https://github.com/fermyon/spin/issues/321, which must be fixed before this can be merged.

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>