### PR TITLE
return after 404

### DIFF
--- a/go-outbound-http/main.go
+++ b/go-outbound-http/main.go
@@ -17,6 +17,7 @@ func init() {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Cannot send HTTP request to %v: %v", url, err)
 			send404(w)
+			return
 		}
 
 		fmt.Fprintln(w, resp.Body)


### PR DESCRIPTION
I think after calling `send404(w)`, we should return