### PR TITLE
Upgrade the spin sdk for golang to 0.6.0

### DIFF
--- a/go-hello/go.mod
+++ b/go-hello/go.mod
@@ -2,4 +2,4 @@ module github.com/fermyon/spin-kitchensink/go-hello
 
 go 1.17
 
-require github.com/fermyon/spin/sdk/go v0.4.0
+require github.com/fermyon/spin/sdk/go v0.6.0

--- a/go-hello/go.mod
+++ b/go-hello/go.mod
@@ -2,4 +2,4 @@ module github.com/fermyon/spin-kitchensink/go-hello
 
 go 1.17
 
-require github.com/fermyon/spin/sdk/go v0.0.0-20220505121948-fdcd127f1558
+require github.com/fermyon/spin/sdk/go v0.4.0

--- a/go-hello/go.sum
+++ b/go-hello/go.sum
@@ -1,2 +1,2 @@
-github.com/fermyon/spin/sdk/go v0.4.0 h1:aUcIK4IPx3gnHgQCIcrJ4sl+HZOITBoxEyp9Z18QqYA=
-github.com/fermyon/spin/sdk/go v0.4.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=
+github.com/fermyon/spin/sdk/go v0.6.0 h1:NHpg0XylARw/6GYpuklaw4M8f2L30hagfoURn9k2duo=
+github.com/fermyon/spin/sdk/go v0.6.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=

--- a/go-hello/go.sum
+++ b/go-hello/go.sum
@@ -1,2 +1,2 @@
-github.com/fermyon/spin/sdk/go v0.0.0-20220505121948-fdcd127f1558 h1:QpqtLZHRXXouvKcBb0MdXbUPQeJJegahJa8c9gVyAAk=
-github.com/fermyon/spin/sdk/go v0.0.0-20220505121948-fdcd127f1558/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=
+github.com/fermyon/spin/sdk/go v0.4.0 h1:aUcIK4IPx3gnHgQCIcrJ4sl+HZOITBoxEyp9Z18QqYA=
+github.com/fermyon/spin/sdk/go v0.4.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=

--- a/go-outbound-http/go.mod
+++ b/go-outbound-http/go.mod
@@ -2,4 +2,4 @@ module github.com/fermyon/spin-kitchensink/go-outbound-http
 
 go 1.17
 
-require github.com/fermyon/spin/sdk/go v0.0.0-20220505121948-fdcd127f1558
+require github.com/fermyon/spin/sdk/go v0.4.0

--- a/go-outbound-http/go.mod
+++ b/go-outbound-http/go.mod
@@ -2,4 +2,4 @@ module github.com/fermyon/spin-kitchensink/go-outbound-http
 
 go 1.17
 
-require github.com/fermyon/spin/sdk/go v0.4.0
+require github.com/fermyon/spin/sdk/go v0.6.0

--- a/go-outbound-http/go.sum
+++ b/go-outbound-http/go.sum
@@ -1,2 +1,2 @@
-github.com/fermyon/spin/sdk/go v0.4.0 h1:aUcIK4IPx3gnHgQCIcrJ4sl+HZOITBoxEyp9Z18QqYA=
-github.com/fermyon/spin/sdk/go v0.4.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=
+github.com/fermyon/spin/sdk/go v0.6.0 h1:NHpg0XylARw/6GYpuklaw4M8f2L30hagfoURn9k2duo=
+github.com/fermyon/spin/sdk/go v0.6.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=

--- a/go-outbound-http/go.sum
+++ b/go-outbound-http/go.sum
@@ -1,2 +1,2 @@
-github.com/fermyon/spin/sdk/go v0.0.0-20220505121948-fdcd127f1558 h1:QpqtLZHRXXouvKcBb0MdXbUPQeJJegahJa8c9gVyAAk=
-github.com/fermyon/spin/sdk/go v0.0.0-20220505121948-fdcd127f1558/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=
+github.com/fermyon/spin/sdk/go v0.4.0 h1:aUcIK4IPx3gnHgQCIcrJ4sl+HZOITBoxEyp9Z18QqYA=
+github.com/fermyon/spin/sdk/go v0.4.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=

--- a/go-static-assets/go.mod
+++ b/go-static-assets/go.mod
@@ -2,4 +2,4 @@ module github.com/fermyon/spin-kitchensink/go-static-assets
 
 go 1.17
 
-require github.com/fermyon/spin/sdk/go v0.0.0-20220505121948-fdcd127f1558
+require github.com/fermyon/spin/sdk/go v0.4.0

--- a/go-static-assets/go.mod
+++ b/go-static-assets/go.mod
@@ -2,4 +2,4 @@ module github.com/fermyon/spin-kitchensink/go-static-assets
 
 go 1.17
 
-require github.com/fermyon/spin/sdk/go v0.4.0
+require github.com/fermyon/spin/sdk/go v0.6.0

--- a/go-static-assets/go.sum
+++ b/go-static-assets/go.sum
@@ -1,2 +1,2 @@
-github.com/fermyon/spin/sdk/go v0.4.0 h1:aUcIK4IPx3gnHgQCIcrJ4sl+HZOITBoxEyp9Z18QqYA=
-github.com/fermyon/spin/sdk/go v0.4.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=
+github.com/fermyon/spin/sdk/go v0.6.0 h1:NHpg0XylARw/6GYpuklaw4M8f2L30hagfoURn9k2duo=
+github.com/fermyon/spin/sdk/go v0.6.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=

--- a/go-static-assets/go.sum
+++ b/go-static-assets/go.sum
@@ -1,2 +1,2 @@
-github.com/fermyon/spin/sdk/go v0.0.0-20220505121948-fdcd127f1558 h1:QpqtLZHRXXouvKcBb0MdXbUPQeJJegahJa8c9gVyAAk=
-github.com/fermyon/spin/sdk/go v0.0.0-20220505121948-fdcd127f1558/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=
+github.com/fermyon/spin/sdk/go v0.4.0 h1:aUcIK4IPx3gnHgQCIcrJ4sl+HZOITBoxEyp9Z18QqYA=
+github.com/fermyon/spin/sdk/go v0.4.0/go.mod h1:ARV2oVtnUCykLM+xCBZq8MQrCZddzb3JbeBettYv1S0=


### PR DESCRIPTION
Using an up-to-date Go / Tinygo with `make spin serve` results in the error described in https://github.com/fermyon/spin/issues/624 as the kitchensink repo uses a particularly old version of the spin sdk.

This PR updates the go dependencies to the latest stable sdk version.

This should also fix https://github.com/fermyon/spin-kitchensink/issues/17