### PR TITLE
tinygo 0.27.0 does not have this flag

### DIFF
--- a/go-hello/Makefile
+++ b/go-hello/Makefile
@@ -1,3 +1,3 @@
 .PHONY: build
 build:
-	tinygo build -wasm-abi=generic -target=wasi -gc=leaking -o main.wasm main.go
+	tinygo build -target=wasi -gc=leaking -o main.wasm main.go

--- a/go-mux/Makefile
+++ b/go-mux/Makefile
@@ -1,3 +1,3 @@
 .PHONY: build
 build:
-	tinygo build -wasm-abi=generic -target=wasi -gc=leaking -o main.wasm main.go
+	tinygo build -target=wasi -gc=leaking -o main.wasm main.go

--- a/go-outbound-http/Makefile
+++ b/go-outbound-http/Makefile
@@ -1,3 +1,3 @@
 .PHONY: build
 build:
-	tinygo build -wasm-abi=generic -target=wasi -gc=leaking -o main.wasm main.go
+	tinygo build -target=wasi -gc=leaking -o main.wasm main.go

--- a/go-static-assets/Makefile
+++ b/go-static-assets/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build
 build:
-	tinygo build -wasm-abi=generic -target=wasi -gc=leaking -o main.wasm main.go
+	tinygo build -target=wasi -gc=leaking -o main.wasm main.go
 
 . PHONY: serve
 serve:


### PR DESCRIPTION
It seems to have been deprecated and removed:

```
-wasm-abi=generic
```

I had other problems with the go examples that I couldn't resolve right away, but they weren't on the critical path for me (I got here from https://www.fermyon.com/blog/spin-rest-apis) so I thought I should just open a report.

Suggested change may be wrong. (Is there an intended version of tinygo that would work with everything? Is the deprecated flag's removal related to whatever changed that caused even `go-hello` to fail in the latest spin, with it compiled this way?)